### PR TITLE
Update Horizon-XI_Windower.yaml

### DIFF
--- a/Horizon-XI_Windower.yaml
+++ b/Horizon-XI_Windower.yaml
@@ -19,9 +19,16 @@ script:
     - xipivot: https://github.com/Shirk/XIPivot/releases/download/v0.4.7/XIPivot_Windower_v0.4.7.zip
   game:
     exe: $WIND_PATH/Windower.exe
-    arch: auto
     prefix: $GAMEDIR
   installer:
+    - task:
+        app: dotnet48
+        description: 'Winetricks: Installing dotnet48'
+        name: winetricks
+    - task:
+        app: gdiplus
+        description: 'Winetricks: Installing gdiplus'
+        name: winetricks
     - copy:
         description: Installing Windower 4
         dst: $WIND_PATH


### PR DESCRIPTION
Hi! Thanks for your scripts! Took me some time but eventually got it to work.
Windower script wouldn't work at all for me, had to apply the following fixes:

`arch: auto` is invalid nowadays, install crashes at the very start.

Also needed to add dotnet48 and gdiplus, without those the Windower would be stuck on its loading screen, never loading the profiles.

From the official lutris script:
https://lutris.net/games/install/37560/view